### PR TITLE
#RIVS-194 - 'Scan More' button is cut off when the panel width is small

### DIFF
--- a/src/webviews/src/components/scan-more/ScanMore.tsx
+++ b/src/webviews/src/components/scan-more/ScanMore.tsx
@@ -28,8 +28,10 @@ export const ScanMore: FC<Props> = ({
       title={disabled ? l10n.t('The entire database has been scanned.') : ''}
     >
       <VscDiffAdded className="mr-1" />
-      <div>{l10n.t('Scan more')}</div>
-      {text && <div className={styles.text}>{text}</div>}
+      <div className={styles.textContainer}>
+        {l10n.t('Scan more')}
+        {text && <div className={styles.text}>{text}</div>}
+      </div>
     </VSCodeButton>
   </div>
 )

--- a/src/webviews/src/components/scan-more/styles.module.scss
+++ b/src/webviews/src/components/scan-more/styles.module.scss
@@ -16,7 +16,12 @@
 }
 
 .text {
-  @apply text-vscode-foreground opacity-80 pl-2;
+  @apply truncate text-vscode-foreground opacity-80 pl-2;
   font-size: 11px;
   line-height: 16px;
+}
+
+.textContainer {
+  @apply flex flex-row truncate;
+  width: calc(100vw - 60px);
 }


### PR DESCRIPTION
#RIVS-194 - 'Scan More' button is cut off when the panel width is small