### PR TITLE
#RIVS-321, #RIVS-324, #RIVS-317, #RIVS-316, #RIVS-322, #RIVS-323

### DIFF
--- a/scripts/downloadBackend.ts
+++ b/scripts/downloadBackend.ts
@@ -82,8 +82,8 @@ async function downloadRedisBackendArchive(
   })
 }
 
-function getNormalizedString(string: string) {
-  return string?.startsWith('D:')
+function getNormalizedCIString(string: string) {
+  return string?.startsWith('D:') && process.env.CI
     ? upath.normalize(string).replace('D:', '/d')
     : string
 }
@@ -96,9 +96,9 @@ function unzipRedisServer(redisInsideArchivePath: string, extractDir: string) {
 
   cp.spawnSync('tar', [
     '-xf',
-    getNormalizedString(redisInsideArchivePath),
+    getNormalizedCIString(redisInsideArchivePath),
     '-C',
-    getNormalizedString(extractDir),
+    getNormalizedCIString(extractDir),
     '--strip-components',
     '1',
     'api',

--- a/src/webviews/src/actions/tests/processCliAction.spec.ts
+++ b/src/webviews/src/actions/tests/processCliAction.spec.ts
@@ -1,0 +1,16 @@
+import * as useCliSettingsThunks from 'uiSrc/modules/cli/hooks/cli-settings/useCliSettingsThunks'
+import { constants } from 'testSrc/helpers'
+import { processCliAction } from 'uiSrc/actions'
+
+vi.spyOn(useCliSettingsThunks, 'addCli')
+
+beforeEach(() => {
+  vi.stubGlobal('ri', { })
+})
+
+describe('processCliAction', () => {
+  it('should call addCli', () => {
+    processCliAction(constants.VSCODE_CLI_ACTION)
+    expect(useCliSettingsThunks.addCli).toBeCalled()
+  })
+})

--- a/src/webviews/src/actions/tests/selectKeyAction.spec.ts
+++ b/src/webviews/src/actions/tests/selectKeyAction.spec.ts
@@ -1,0 +1,23 @@
+import * as useSelectedKey from 'uiSrc/store/hooks/use-selected-key-store/useSelectedKeyStore'
+import { selectKeyAction } from 'uiSrc/actions'
+import { constants } from 'testSrc/helpers'
+
+
+vi.spyOn(useSelectedKey, 'fetchKeyInfo')
+
+
+beforeEach(() => {
+  vi.stubGlobal('ri', { })
+
+  useSelectedKey.useSelectedKeyStore.setState((state) => ({
+    ...state,
+    data: constants.KEY_INFO,
+  }))
+})
+
+describe('selectKeyAction', () => {
+  it('should call fetchKeyInfo', () => {
+    selectKeyAction(constants.VSCODE_SELECT_KEY_ACTION)
+    expect(useSelectedKey.fetchKeyInfo).toBeCalled()
+  })
+})

--- a/src/webviews/src/components/auto-refresh/AutoRefresh.tsx
+++ b/src/webviews/src/components/auto-refresh/AutoRefresh.tsx
@@ -199,6 +199,8 @@ const AutoRefresh = React.memo(({
       </Tooltip>
 
       <Popover
+        closeOnEscape
+        closeOnDocumentClick
         repositionOnResize
         keepTooltipInside={false}
         open={isPopoverOpen}

--- a/src/webviews/src/components/auto-refresh/styles.module.scss
+++ b/src/webviews/src/components/auto-refresh/styles.module.scss
@@ -20,8 +20,7 @@
 
 
 :global(.popover-auto-refresh-content) {
-  @apply max-w-[225px] w-[225px] #{!important};
-
+  @apply pr-[26px] #{!important};
 }
 
 .switch {

--- a/src/webviews/src/constants/core/storage.ts
+++ b/src/webviews/src/constants/core/storage.ts
@@ -32,6 +32,7 @@ enum StorageItem {
   databaseId = 'databaseId',
   openTreeNode = 'openTreeNode',
   openTreeDatabase = 'openTreeDatabase',
+  keysTreeFilter = 'keysTreeFilter',
 }
 
 export { StorageItem }

--- a/src/webviews/src/modules/key-details-header/KeyDetailsHeader.tsx
+++ b/src/webviews/src/modules/key-details-header/KeyDetailsHeader.tsx
@@ -157,7 +157,7 @@ const KeyDetailsHeader = ({
           </div>
         )}
       </AutoSizer>
-      {(loading || refreshing) && <div className="table-loading" />}
+      {(loading || refreshing) && <div className="data-loading" />}
     </div>
   )
 }

--- a/src/webviews/src/modules/key-details/components/hash-details/HashDetails.tsx
+++ b/src/webviews/src/modules/key-details/components/hash-details/HashDetails.tsx
@@ -84,7 +84,7 @@ const HashDetails = (props: Props) => {
     ),
     children,
     <AddItemsAction key={3} title={l10n.t('Add Fields')} openAddItemPanel={openAddItemPanel} />,
-  ]), [])
+  ]), [showTtl, isExpireFieldsAvailable])
 
   return (
     <div className="fluid flex-column relative">

--- a/src/webviews/src/modules/key-details/components/string-details/StringDetails.tsx
+++ b/src/webviews/src/modules/key-details/components/string-details/StringDetails.tsx
@@ -103,7 +103,7 @@ const StringDetails = (props: Props) => {
         setEditItem(!editItem)
       }}
     />,
-  ]), [])
+  ]), [isStringEditable, isEditable])
 
   return (
     <div className="fluid flex-column relative">

--- a/src/webviews/src/modules/keys-tree/components/database-wrapper/DatabaseWrapper.spec.tsx
+++ b/src/webviews/src/modules/keys-tree/components/database-wrapper/DatabaseWrapper.spec.tsx
@@ -8,6 +8,7 @@ import { apiService, vscodeApi } from 'uiSrc/services'
 import * as useContext from 'uiSrc/store/hooks/use-context/useContext'
 import * as useSelectedKeyStore from 'uiSrc/store/hooks/use-selected-key-store/useSelectedKeyStore'
 import { Database } from 'uiSrc/store'
+import * as useDatabasesStore from 'uiSrc/store'
 import { constants, fireEvent, render, waitForStack } from 'testSrc/helpers'
 import { DatabaseWrapper, Props } from './DatabaseWrapper'
 import * as useKeys from '../../hooks/useKeys'
@@ -39,12 +40,23 @@ const resetKeysTreeMock = vi.fn();
   resetKeysTree: resetKeysTreeMock,
 }))
 
+vi.spyOn(useDatabasesStore, 'fetchDatabaseOverviewById')
+
 describe('DatabaseWrapper', () => {
   it('should render', () => {
     expect(render(<DatabaseWrapper {...mockedProps} />)).toBeTruthy()
   })
 
-  it('should call fetchPatternKeysAction action after click on refresh icon', async () => {
+  it('should call fetchDatabaseOverviewById action after click on refresh icon', async () => {
+    const { queryByTestId } = render(<DatabaseWrapper {...mockedProps} />)
+
+    fireEvent.click(queryByTestId('refresh-databases')!)
+    await waitForStack()
+
+    expect(useDatabasesStore.fetchDatabaseOverviewById).toBeCalled()
+  })
+
+  it('should call fetchPatternKeysAction action after click on logical database refresh icon', async () => {
     const { queryByTestId } = render(<DatabaseWrapper {...mockedProps} />)
 
     fireEvent.click(queryByTestId(`database-${mockDatabase.id}`)!)

--- a/src/webviews/src/modules/keys-tree/components/keys-summary/KeysSummary.tsx
+++ b/src/webviews/src/modules/keys-tree/components/keys-summary/KeysSummary.tsx
@@ -159,10 +159,12 @@ export const KeysSummary = (props: Props) => {
       )} */}
 
       <div className={cx('hidden', 'pr-3.5', 'group-hover:!flex', { '!flex': showTree })}>
+        <KeyTreeFilter />
         <Tooltip
+          repositionOnResize
           keepTooltipInside={false}
           content={l10n.t('Sort by key names displayed')}
-          position="bottom right"
+          position="bottom center"
         >
           <VSCodeButton
             appearance="icon"
@@ -172,7 +174,6 @@ export const KeysSummary = (props: Props) => {
             {isSortingASC ? <BiSortDown /> : <BiSortUp />}
           </VSCodeButton>
         </Tooltip>
-        <KeyTreeFilter />
         <VSCodeButton appearance="icon" onClick={addKeyClickHandle} data-testid="add-key-button">
           <VscAdd />
         </VSCodeButton>

--- a/src/webviews/src/modules/keys-tree/components/keys-tree-header/KeysTreeHeader.tsx
+++ b/src/webviews/src/modules/keys-tree/components/keys-tree-header/KeysTreeHeader.tsx
@@ -36,6 +36,10 @@ export const KeysTreeHeader = ({ database, open, dbTotal, children }: Props) => 
   }
 
   useEffect(() => {
+    keysApi.fetchPatternKeysAction()
+  }, [dbTotal, total])
+
+  useEffect(() => {
     if (showTree) {
       sendEventTelemetry({
         event: TelemetryEvent.BROWSER_DATABASE_INDEX_CHANGED,
@@ -66,7 +70,7 @@ export const KeysTreeHeader = ({ database, open, dbTotal, children }: Props) => 
         database={database}
         loading={loading}
         scanned={scanned}
-        total={dbTotal ?? total}
+        total={showTree ? total : (dbTotal ?? null)}
         dbIndex={dbIndex}
         resultsLength={resultsLength}
         showTree={showTree}

--- a/src/webviews/src/modules/keys-tree/components/virtual-tree/VirtualTree.tsx
+++ b/src/webviews/src/modules/keys-tree/components/virtual-tree/VirtualTree.tsx
@@ -269,7 +269,7 @@ const VirtualTree = (props: Props) => {
                 itemSize={22}
                 treeWalker={treeWalker}
                 onItemsRendered={onItemsRendered}
-                className={cx(styles.customScroll, { 'table-loading': loading })}
+                className={cx(styles.customScroll, { 'data-loading': loading })}
               >
                 {Node}
               </Tree>

--- a/src/webviews/src/modules/keys-tree/hooks/useKeysThunks.ts
+++ b/src/webviews/src/modules/keys-tree/hooks/useKeysThunks.ts
@@ -261,7 +261,7 @@ KeysThunks
           eventData: {
             keyType,
             TTL: data.expire || -1,
-            databaseId: sessionStorageService.get(StorageItem.databaseId),
+            databaseId: window.ri?.database?.id ?? null,
             length: getLengthByKeyType(keyType, data),
           },
         })

--- a/src/webviews/src/store/hooks/use-databases-store/useDatabasesStore.ts
+++ b/src/webviews/src/store/hooks/use-databases-store/useDatabasesStore.ts
@@ -178,6 +178,7 @@ export const fetchDatabaseById = async (databaseId: string, onSuccess?: (data: D
 
 export const fetchDatabaseOverviewById = async (databaseId: string): Promise<Nullable<DatabaseOverview>> => {
   try {
+    useDatabasesStore.getState().processDatabase()
     const { data, status } = await apiService.get<DatabaseOverview>(
       `${ApiEndpoints.DATABASES}/${databaseId}/overview`,
       { params: { keyspace: 'full' },
@@ -188,6 +189,8 @@ export const fetchDatabaseOverviewById = async (databaseId: string): Promise<Nul
     }
   } catch (error) {
     showErrorMessage(getApiErrorMessage(error as AxiosError))
+  } finally {
+    useDatabasesStore.getState().processDatabaseFinal()
   }
 
   return null

--- a/src/webviews/test/helpers/constants.ts
+++ b/src/webviews/test/helpers/constants.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid'
-import { DEFAULT_ERROR_MESSAGE, DEFAULT_SEARCH_MATCH, KeyTypes } from 'uiSrc/constants'
-import { KeyInfo } from 'uiSrc/interfaces'
+import { DEFAULT_ERROR_MESSAGE, DEFAULT_SEARCH_MATCH, KeyTypes, VscodeMessageAction } from 'uiSrc/constants'
+import { CliAction, KeyInfo, SelectKeyAction } from 'uiSrc/interfaces'
 import { Certificate } from 'uiSrc/store/hooks/use-certificates-store/interface'
 import { UTF8ToArray, stringToBuffer } from 'uiSrc/utils'
 import { Database } from 'uiSrc/store'
@@ -196,6 +196,14 @@ export const constants = {
     return ['info', 'server']
   },
 
+  get VSCODE_SELECT_KEY_ACTION() {
+    return VSCODE_SELECT_KEY_ACTION
+  },
+
+  get VSCODE_CLI_ACTION() {
+    return VSCODE_CLI_ACTION
+  },
+
   SERVER_INFO: {
     id: 'cceadb87-d2aa-47be-b647-5be34dcb8636',
     createDateTime: '2024-02-27T13:10:54.000Z',
@@ -354,5 +362,24 @@ const REDIS_COMMANDS = {
     ],
     arity: -2,
     provider: 'main',
+  },
+}
+
+const VSCODE_SELECT_KEY_ACTION: SelectKeyAction = {
+  action: VscodeMessageAction.SelectKey,
+  data: {
+    database: constants.DATABASE,
+    keyInfo: {
+      key: constants.KEY_NAME_2,
+      keyString: constants.KEY_NAME_HASH_2,
+      keyType: constants.KEY_TYPE_2,
+    },
+  },
+}
+
+const VSCODE_CLI_ACTION: CliAction = {
+  action: VscodeMessageAction.AddCli,
+  data: {
+    database: constants.DATABASE,
   },
 }

--- a/src/webviews/vscode.css
+++ b/src/webviews/vscode.css
@@ -63,7 +63,7 @@ vscode-button::part(control) {
   }
 }
 
-.table-loading:before {
+.data-loading:before {
   position: absolute;
   content: '';
   width: 100%;

--- a/tests/e2e/src/page-objects/components/tree-view/TreeView.ts
+++ b/tests/e2e/src/page-objects/components/tree-view/TreeView.ts
@@ -44,7 +44,7 @@ export class TreeView extends WebView {
   keyTreeFilterCancelBtn = By.xpath(
     `//vscode-button[@data-testid='key-tree-filter-cancel-btn']`,
   )
-  loadingIndicator = By.xpath(`//*[contains(@class, "table-loading")]`)
+  loadingIndicator = By.xpath(`//*[contains(@class, "data-loading")]`)
   treeViewFilterSelect = By.xpath(
     `//vscode-dropdown[@data-testid='tree-view-filter-select']`,
   )

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -82,7 +82,6 @@ export default defineConfig({
     testTimeout: 20000,
     setupFiles: ['./src/webviews/test/setup.ts'],
     coverage: {
-      enabled: true,
       reporter: ['text', 'html'],
       reportsDirectory: './report/coverage',
       include: ['src/webviews/src/**'],


### PR DESCRIPTION
* #RIVS-321 - Keys count is not updated for logical db
* #RIVS-324 - There is no common refresh for the logical db
* #RIVS-317 - Filters not saved when switching between extensions
* #RIVS-316 - Filters/sorting dropdown can be overlapped
* #RIVS-322 - databaseId is null for TREE_VIEW_KEY_ADDED
* #RIVS-323 - Show TTL checkbox doesn't work
* #RIVS-325 - Edit String key button not disabled for not loaded key with > 5000 characters