### PR TITLE
RI-6931: Require login on every free cloud db creation

### DIFF
--- a/src/webviews/src/modules/oauth/oauth-sso/oauth-create-db/OAuthCreateDb.spec.tsx
+++ b/src/webviews/src/modules/oauth/oauth-sso/oauth-create-db/OAuthCreateDb.spec.tsx
@@ -8,7 +8,7 @@ import { initialOAuthState, useOAuthStore } from 'uiSrc/store'
 import { INFINITE_MESSAGES } from 'uiSrc/components'
 import { act, cleanup, constants, fireEvent, render, screen } from 'testSrc/helpers'
 import OAuthCreateDb from './OAuthCreateDb'
-import { LOGIN_EVERY_TIME } from './constants'
+import { REQUIRE_LOGIN_ON_NEW_DB } from './constants'
 
 vi.spyOn(utils, 'sendEventTelemetry')
 vi.spyOn(utils, 'showInfinityToast')
@@ -107,7 +107,7 @@ describe('OAuthCreateDb', () => {
     expect(useOAuthStore.getState().isOpenSocialDialog).toEqual(false)
   })
 
-  it.skipIf(LOGIN_EVERY_TIME)('should render proper components when user is logged in', () => {
+  it.skipIf(REQUIRE_LOGIN_ON_NEW_DB)('should render proper components when user is logged in', () => {
     useOAuthStore.setState({ ...initialOAuthState,
       agreement: true,
       user: {
@@ -126,7 +126,7 @@ describe('OAuthCreateDb', () => {
     expect(screen.queryByTestId('oauth-container-social-buttons')).not.toBeInTheDocument()
   })
 
-  it.skipIf(!LOGIN_EVERY_TIME)('should render oauth form elements if user logged in', () => {
+  it.skipIf(!REQUIRE_LOGIN_ON_NEW_DB)('should render oauth form elements if user logged in', () => {
     useOAuthStore.setState({ ...initialOAuthState,
       agreement: true,
       user: {
@@ -145,7 +145,7 @@ describe('OAuthCreateDb', () => {
     expect(screen.queryByTestId('oauth-create-db')).not.toBeInTheDocument()
   })
 
-  it.skipIf(LOGIN_EVERY_TIME)('should call proper actions after click create', async () => {
+  it.skipIf(REQUIRE_LOGIN_ON_NEW_DB)('should call proper actions after click create', async () => {
     const name = CloudJobName.CreateFreeSubscriptionAndDatabase
     useOAuthStore.setState({ ...initialOAuthState,
       agreement: true,
@@ -169,7 +169,7 @@ describe('OAuthCreateDb', () => {
     )
   })
 
-  it.skipIf(LOGIN_EVERY_TIME)('should call proper actions after click create without recommened settings', async () => {
+  it.skipIf(REQUIRE_LOGIN_ON_NEW_DB)('should call proper actions after click create without recommened settings', async () => {
     useOAuthStore.setState({ ...initialOAuthState,
       agreement: true,
       source: 'source',

--- a/src/webviews/src/modules/oauth/oauth-sso/oauth-create-db/OAuthCreateDb.tsx
+++ b/src/webviews/src/modules/oauth/oauth-sso/oauth-create-db/OAuthCreateDb.tsx
@@ -10,7 +10,7 @@ import { createFreeDbJob, fetchCloudSubscriptionPlans, useOAuthStore } from 'uiS
 import { Spacer } from 'uiSrc/ui'
 import { INFINITE_MESSAGES } from 'uiSrc/components'
 
-import { LOGIN_EVERY_TIME } from './constants'
+import { REQUIRE_LOGIN_ON_NEW_DB } from './constants'
 import { OAuthForm } from '../../shared/oauth-form'
 import OAuthAgreement from '../../shared/oauth-agreement/OAuthAgreement'
 import { OAuthAdvantages, OAuthRecommendedSettings } from '../../shared'
@@ -86,7 +86,7 @@ const OAuthCreateDb = (props: Props) => {
         <OAuthAdvantages />
       </div>
       <div className={styles.socialContainer}>
-        {!data || LOGIN_EVERY_TIME ? (
+        {!data || REQUIRE_LOGIN_ON_NEW_DB ? (
           <OAuthForm
             className={styles.socialButtons}
             onClick={handleSocialButtonClick}

--- a/src/webviews/src/modules/oauth/oauth-sso/oauth-create-db/OAuthCreateDb.tsx
+++ b/src/webviews/src/modules/oauth/oauth-sso/oauth-create-db/OAuthCreateDb.tsx
@@ -10,6 +10,7 @@ import { createFreeDbJob, fetchCloudSubscriptionPlans, useOAuthStore } from 'uiS
 import { Spacer } from 'uiSrc/ui'
 import { INFINITE_MESSAGES } from 'uiSrc/components'
 
+import { LOGIN_EVERY_TIME } from './constants'
 import { OAuthForm } from '../../shared/oauth-form'
 import OAuthAgreement from '../../shared/oauth-agreement/OAuthAgreement'
 import { OAuthAdvantages, OAuthRecommendedSettings } from '../../shared'
@@ -85,7 +86,7 @@ const OAuthCreateDb = (props: Props) => {
         <OAuthAdvantages />
       </div>
       <div className={styles.socialContainer}>
-        {!data ? (
+        {!data || LOGIN_EVERY_TIME ? (
           <OAuthForm
             className={styles.socialButtons}
             onClick={handleSocialButtonClick}

--- a/src/webviews/src/modules/oauth/oauth-sso/oauth-create-db/constants.ts
+++ b/src/webviews/src/modules/oauth/oauth-sso/oauth-create-db/constants.ts
@@ -1,0 +1,4 @@
+// TODO [DA]: Remove once logout is implemented and it is decided that this functionality no longer needed
+// Added in order to give flexibility to the user to login every time and change cloud accounts
+// on each create free db event
+export const LOGIN_EVERY_TIME: boolean = true

--- a/src/webviews/src/modules/oauth/oauth-sso/oauth-create-db/constants.ts
+++ b/src/webviews/src/modules/oauth/oauth-sso/oauth-create-db/constants.ts
@@ -1,4 +1,4 @@
 // TODO [DA]: Remove once logout is implemented and it is decided that this functionality no longer needed
 // Added in order to give flexibility to the user to login every time and change cloud accounts
 // on each create free db event
-export const LOGIN_EVERY_TIME: boolean = true
+export const REQUIRE_LOGIN_ON_NEW_DB: boolean = true


### PR DESCRIPTION
Since there is no login functionality, a login should be required for every free cloud database creation so that the user can re-authenticate with the desired cloud account.
So, when user is logged in, instead of this modal:
![image](https://github.com/user-attachments/assets/4abc0430-68fb-4b90-b89f-930ca19c2af7)
the initial modal for logging in will be shown every time:
![image](https://github.com/user-attachments/assets/5c176f84-9e51-4cc9-a2df-a39c79c0ecd9)

