### PR TITLE
RI-7027: Add JSON key -> Create free db dialog

### DIFF
--- a/src/webviews/src/constants/cloud/source.ts
+++ b/src/webviews/src/constants/cloud/source.ts
@@ -10,6 +10,7 @@ export enum OAuthSocialSource {
   BrowserContentMenu = 'browser content menu',
   BrowserFiltering = 'browser filtering',
   BrowserSearch = 'browser search',
+  BrowserRedisJSON = 'browser RedisJSON',
   RediSearch = 'workbench RediSearch',
   RedisJSON = 'workbench RedisJSON',
   RedisTimeSeries = 'workbench RedisTimeSeries',

--- a/src/webviews/src/constants/window/helpTexts.tsx
+++ b/src/webviews/src/constants/window/helpTexts.tsx
@@ -8,11 +8,15 @@ import { EXTERNAL_LINKS, UTM_CAMPAIGNS } from 'uiSrc/constants'
 import styles from 'uiSrc/components/popover-delete/styles.module.scss'
 
 export const helpTexts = {
-  REJSON_SHOULD_BE_LOADED: (
+  REJSON_SHOULD_BE_LOADED: (onFreeTrialDbClick: () => void) => (
     <>
-      {l10n.t('This database does not support the JSON data structure. Learn more about JSON support ')}
+      {l10n.t(
+        'This database does not support the JSON data structure. Learn more about JSON support ',
+      )}
       <Link
-        to={getUtmExternalLink(EXTERNAL_LINKS.jsonModule, { campaign: UTM_CAMPAIGNS.tutorials })}
+        to={getUtmExternalLink(EXTERNAL_LINKS.jsonModule, {
+          campaign: UTM_CAMPAIGNS.tutorials,
+        })}
         className="underline hover:no-underline"
         target="_blank"
         data-test-subj="no-json-module-info"
@@ -20,14 +24,14 @@ export const helpTexts = {
         {l10n.t('here. ')}
       </Link>
       {l10n.t('You can also create a ')}
-      <Link
-        to={getUtmExternalLink(EXTERNAL_LINKS.tryFree, { campaign: UTM_CAMPAIGNS.redisjson })}
+      <a
+        onClick={onFreeTrialDbClick}
         className="underline hover:no-underline"
-        target="_blank"
         data-test-subj="no-json-module-try-free"
+        href="#"
       >
         {l10n.t('free trial Redis Cloud database')}
-      </Link>
+      </a>
       {l10n.t(' with built-in JSON support.')}
     </>
   ),
@@ -35,15 +39,22 @@ export const helpTexts = {
     <div className={styles.appendInfo}>
       <VscWarning className="mr-1 mt-1" />
       <span>
-        {l10n.t('If you remove the single {0}, the whole Key will be deleted.', fieldType)}
+        {l10n.t(
+          'If you remove the single {0}, the whole Key will be deleted.',
+          fieldType,
+        )}
       </span>
     </div>
   ),
   REMOVING_MULTIPLE_ELEMENTS_NOT_SUPPORT: (
     <>
-      {l10n.t('Removing multiple elements is available for Redis databases v. 6.2 or later. Update your Redis database or create a new ')}
+      {l10n.t(
+        'Removing multiple elements is available for Redis databases v. 6.2 or later. Update your Redis database or create a new ',
+      )}
       <Link
-        to={getUtmExternalLink(EXTERNAL_LINKS.tryFree, { campaign: UTM_CAMPAIGNS.redisLatest })}
+        to={getUtmExternalLink(EXTERNAL_LINKS.tryFree, {
+          campaign: UTM_CAMPAIGNS.redisLatest,
+        })}
         className="underline hover:no-underline"
         target="_blank"
         data-test-subj="no-json-module-try-free"

--- a/src/webviews/src/constants/window/helpTexts.tsx
+++ b/src/webviews/src/constants/window/helpTexts.tsx
@@ -24,14 +24,14 @@ export const helpTexts = {
         {l10n.t('here. ')}
       </Link>
       {l10n.t('You can also create a ')}
-      <a
+      <Link
         onClick={onFreeTrialDbClick}
         className="underline hover:no-underline"
         data-testid="no-json-module-create-free-db"
-        href="#"
+        to=""
       >
         {l10n.t('free trial Redis Cloud database')}
-      </a>
+      </Link>
       {l10n.t(' with built-in JSON support.')}
     </>
   ),

--- a/src/webviews/src/constants/window/helpTexts.tsx
+++ b/src/webviews/src/constants/window/helpTexts.tsx
@@ -19,7 +19,7 @@ export const helpTexts = {
         })}
         className="underline hover:no-underline"
         target="_blank"
-        data-test-subj="no-json-module-info"
+        data-testid="no-json-module-info"
       >
         {l10n.t('here. ')}
       </Link>
@@ -27,7 +27,7 @@ export const helpTexts = {
       <a
         onClick={onFreeTrialDbClick}
         className="underline hover:no-underline"
-        data-test-subj="no-json-module-try-free"
+        data-testid="no-json-module-create-free-db"
         href="#"
       >
         {l10n.t('free trial Redis Cloud database')}

--- a/src/webviews/src/modules/add-key/AddKey.spec.tsx
+++ b/src/webviews/src/modules/add-key/AddKey.spec.tsx
@@ -29,36 +29,4 @@ describe('AddKey', () => {
 
     expect((screen.getByTestId('select-key-type') as HTMLInputElement).value).toBe(ADD_KEY_TYPE_OPTIONS[0].value)
   })
-
-  // it('should show text if db not contains ReJSON module', async () => {
-  //   render(<AddKey
-  //   />)
-
-  //   fireEvent.click(screen.getByTestId('select-key-type'))
-  //   await waitFor(() => {
-  //     fireEvent.click(
-  //       screen.queryByText('JSON') || document,
-  //     )
-  //   })
-
-  //   expect(screen.getByTestId('json-not-loaded-text')).toBeInTheDocument()
-  // })
-
-  // it('should not show text if db contains ReJSON module', async () => {
-  //   (connectedInstanceSelector as vi.Mock).mockImplementation(() => ({
-  //     modules: [{ name: RedisDefaultModules.FT }, { name: RedisDefaultModules.ReJSON }],
-  //   }))
-
-  //   render(<AddKey
-  //   />)
-
-  //   fireEvent.click(screen.getByTestId('select-key-type'))
-  //   await waitFor(() => {
-  //     fireEvent.click(
-  //       screen.queryByText('JSON') || document,
-  //     )
-  //   })
-
-  //   expect(screen.queryByTestId('json-not-loaded-text')).not.toBeInTheDocument()
-  // })
 })

--- a/src/webviews/src/modules/add-key/AddKey.tsx
+++ b/src/webviews/src/modules/add-key/AddKey.tsx
@@ -4,7 +4,6 @@ import { KeyTypes, SelectedKeyActionType, VscodeMessageAction } from 'uiSrc/cons
 
 import { Maybe } from 'uiSrc/interfaces'
 import { vscodeApi } from 'uiSrc/services'
-import { useDatabasesStore } from 'uiSrc/store'
 import { getGroupTypeDisplay, stringToBuffer } from 'uiSrc/utils'
 
 import AddKeyCommonFields from './components/AddKeyCommonFields/AddKeyCommonFields'
@@ -23,7 +22,6 @@ import styles from './styles.module.scss'
 export const AddKey = () => {
   const loading = useKeysInContext((state) => state.addKeyLoading)
   const keysApi = useKeysApi()
-  const database = useDatabasesStore((state) => state.connectedDatabase)
 
   useEffect(
     () =>

--- a/src/webviews/src/modules/add-key/components/AddKeyReJSON/AddKeyReJSON.spec.tsx
+++ b/src/webviews/src/modules/add-key/components/AddKeyReJSON/AddKeyReJSON.spec.tsx
@@ -2,9 +2,43 @@ import React from 'react'
 import { instance, mock } from 'ts-mockito'
 
 import * as utils from 'uiSrc/utils'
-import { render } from 'testSrc/helpers'
+import {
+  Database,
+  DatabasesStore,
+  initialDatabasesState,
+  useDatabasesStore,
+} from 'uiSrc/store'
+import { ConnectionType, Nullable, RedisDefaultModules } from 'uiSrc/interfaces'
+import { OAuthSsoDialog } from 'uiSrc/modules/oauth'
+import { fireEvent, render, screen } from 'testSrc/helpers'
 
 import { AddKeyReJSON, Props } from './AddKeyReJSON'
+
+const mockConnectedDatabase: Nullable<Database> = {
+  ...initialDatabasesState.connectedDatabase,
+  id: 'mocked-id',
+  name: 'mocked-database',
+  host: '127.0.0.1',
+  port: 6379,
+  modules: [],
+  username: 'mocked-user',
+  password: 'mocked-password',
+  tls: false,
+  db: 0,
+  lastConnection: new Date(),
+  provider: 'RE_CLOUD',
+  connectionType: ConnectionType.Standalone,
+  version: null,
+}
+
+const customState: DatabasesStore = {
+  ...initialDatabasesState,
+  connectedDatabase: mockConnectedDatabase,
+}
+
+beforeEach(() => {
+  useDatabasesStore.setState(customState)
+})
 
 const mockedProps = mock<Props>()
 
@@ -16,6 +50,73 @@ describe('AddKeyReJSON', () => {
   })
 
   it('should render', () => {
-    expect(render(<AddKeyReJSON {...instance(mockedProps)} />, { withRouter: true })).toBeTruthy()
+    expect(
+      render(<AddKeyReJSON {...instance(mockedProps)} />, { withRouter: true }),
+    ).toBeTruthy()
+  })
+
+  it('should not display the JSON not supported text when JSON module is available', () => {
+    useDatabasesStore.setState({
+      ...customState,
+      connectedDatabase: {
+        ...mockConnectedDatabase,
+        modules: [
+          {
+            name: RedisDefaultModules.ReJSON,
+          },
+        ],
+      },
+    })
+
+    const { queryByTestId } = render(
+      <AddKeyReJSON {...instance(mockedProps)} />,
+      { withRouter: true },
+    )
+
+    const textId = 'json-not-loaded-text'
+    expect(queryByTestId(textId)).not.toBeInTheDocument()
+  })
+
+  it('should display the JSON not supported text when JSON module is not available', () => {
+    useDatabasesStore.setState({
+      ...customState,
+      connectedDatabase: {
+        ...mockConnectedDatabase,
+        modules: [],
+      },
+    })
+
+    const { queryByTestId } = render(
+      <AddKeyReJSON {...instance(mockedProps)} />,
+      { withRouter: true },
+    )
+
+    const textId = 'json-not-loaded-text'
+    expect(queryByTestId(textId)).toBeInTheDocument()
+  })
+
+  it('should open sso oauth dialog when free trial redis cloud database link clicked', () => {
+    useDatabasesStore.setState({
+      ...customState,
+      connectedDatabase: {
+        ...mockConnectedDatabase,
+        modules: [],
+      },
+    })
+
+    const { queryByTestId } = render(
+      <AddKeyReJSON {...instance(mockedProps)} />,
+      { withRouter: true },
+    )
+    render(<OAuthSsoDialog />)
+
+    const oauthDialogId = 'social-oauth-dialog'
+    expect(screen.queryByTestId(oauthDialogId)).not.toBeInTheDocument()
+
+    const linkId = 'no-json-module-create-free-db'
+    expect(queryByTestId(linkId)).toBeInTheDocument()
+    fireEvent.click(queryByTestId(linkId) as HTMLAnchorElement)
+
+    expect(screen.queryByTestId(oauthDialogId)).toBeInTheDocument()
   })
 })

--- a/src/webviews/src/modules/oauth/oauth-create-free-db/OAuthCreateFreeDb.spec.tsx
+++ b/src/webviews/src/modules/oauth/oauth-create-free-db/OAuthCreateFreeDb.spec.tsx
@@ -81,13 +81,14 @@ describe('OAuthCreateFreeDb', () => {
 
     // component is initialized in the document, but the state is not updated yet to show the dialog
     render(<OAuthSsoDialog />)
-    expect(screen.queryByTestId('social-oauth-dialog')).not.toBeInTheDocument()
+    const oauthDialogId = 'social-oauth-dialog'
+    expect(screen.queryByTestId(oauthDialogId)).not.toBeInTheDocument()
 
     const regularCreateBtn = queryByTestId('create-free-db-btn')
     expect(regularCreateBtn).toBeInTheDocument()
 
     fireEvent.click(regularCreateBtn as HTMLButtonElement)
 
-    expect(screen.queryByTestId('social-oauth-dialog')).toBeInTheDocument()
+    expect(screen.queryByTestId(oauthDialogId)).toBeInTheDocument()
   })
 })

--- a/src/webviews/src/pages/AddKeyPage/AddKeyPage.tsx
+++ b/src/webviews/src/pages/AddKeyPage/AddKeyPage.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react'
 import { AddKey } from 'uiSrc/modules'
 import { KeysStoreProvider } from 'uiSrc/modules/keys-tree/hooks/useKeys'
+import { OAuthSsoDialog } from 'uiSrc/modules/oauth'
 import { ContextStoreProvider } from 'uiSrc/store'
 
 export const AddKeyPage: FC<any> = () => (
@@ -8,6 +9,7 @@ export const AddKeyPage: FC<any> = () => (
     <ContextStoreProvider>
       <KeysStoreProvider>
         <AddKey />
+        <OAuthSsoDialog />
       </KeysStoreProvider>
     </ContextStoreProvider>
   </div>


### PR DESCRIPTION
Same as this PR -> https://github.com/RedisInsight/RedisInsight/pull/4473, applying here as well.

When json module does not exist in the redis DB, we want the `free trial Redis Cloud database` button to open the oauth sso modal and allow the user to create a cloud database. 

Applied some formatting and refactoring to some files as well

Prerequisites:
- The database does not contain JSON module (ex. not a redis stack db, just simple redis 7 server instance)