### PR TITLE
RI-7010: add logging for unidentified error responses

### DIFF
--- a/src/webviews/src/utils/core/errors.tsx
+++ b/src/webviews/src/utils/core/errors.tsx
@@ -198,6 +198,7 @@ export const parseCustomError = (err: CustomError | string = DEFAULT_ERROR_MESSA
     default:
       title = 'Error'
       message = err?.message || DEFAULT_ERROR_MESSAGE
+      console.warn('Unidentified error response:', err)
       break
   }
 


### PR DESCRIPTION
## Description 

Issue: When an unidentified error occurs, we display a generic "Something was wrong!" message, omitting the error object.
Solution: Add logging for unidentified error responses.

Related issue: https://github.com/RedisInsight/Redis-for-VS-Code/issues/219