### PR TITLE
DEV: Simplify repo configuration

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npx lint-staged

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "editor.formatOnSave": true,
   "css.customData": [".vscode/css_custom_data.json"],
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
   "[javascript, typescript, typescriptreact]": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,8 +20,6 @@
     "strings": "on"
   },
   "files.eol": "\n",
-  "javascript.inlayHints.parameterNames.enabled": "all",
-  "typescript.inlayHints.parameterNames.enabled": "all",
   "[scss]": {
     "editor.defaultFormatter": "sibiraj-s.vscode-scss-formatter"
   },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,5 @@
 {
   "css.customData": [".vscode/css_custom_data.json"],
-  "editor.defaultFormatter": "dbaeumer.vscode-eslint",
-  "[javascript, typescript, typescriptreact]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
   "eslint.format.enable": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
@@ -20,9 +16,6 @@
     "strings": "on"
   },
   "files.eol": "\n",
-  "[scss]": {
-    "editor.defaultFormatter": "sibiraj-s.vscode-scss-formatter"
-  },
   "search.exclude": {
     "**/*.svg": true,
     "dist": true,
@@ -52,11 +45,5 @@
     "webviews",
     "zustand"
   ],
-  "testing.automaticallyOpenPeekView": "never",
-  "[typescriptreact]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "[typescript]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  }
+  "testing.automaticallyOpenPeekView": "never"
 }

--- a/package.json
+++ b/package.json
@@ -160,8 +160,7 @@
     "test:watch:ui": "vitest watch --ui --coverage --dir ./src/webviews/src",
     "test:cov": "vitest run --silent --coverage --dir ./src/webviews/src",
     "package:prod": "npx mkdirp release && npx @vscode/vsce package",
-    "package:stage": "npx mkdirp release && npx @vscode/vsce package --pre-release",
-    "prepare": "husky install"
+    "package:stage": "npx mkdirp release && npx @vscode/vsce package --pre-release"
   },
   "vsce": {
     "yarn": true,
@@ -223,7 +222,6 @@
     "eslint-plugin-tailwindcss": "^3.15.1",
     "googleapis": "^142.0.0",
     "html-entities": "^2.3.2",
-    "husky": "^8.0.3",
     "jsdom": "^22.1.0",
     "jsdom-worker": "^0.3.0",
     "lint-staged": "^15.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4989,11 +4989,6 @@ human-signals@^5.0.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-5.0.0.tgz#42665a284f9ae0dade3ba41ebc37eb4b852f3a28"
   integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
 
-husky@^8.0.3:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
-  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
-
 iconv-lite@0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"


### PR DESCRIPTION
Two main things are going on here:

- vscode setup - disable inline suggestions and leave default format options to the user's choice
- remove husky

Why?

- Inline suggestions are very subjective manner (see the screenshot), so I'm using the default option for the desktop repo (these options are disabled)

<img width="212" alt="Screenshot 2025-05-21 at 11 46 54" src="https://github.com/user-attachments/assets/b6ed1a02-2fd1-46c2-9e22-7a6037172ea7" />

- Default formatters - same. In upcoming PRs, we'll fix eslint and prettier and will rely on them for formatting
- husky - it runs the `lint` script, which currently is just a noise (check the screenshot)

<img width="522" alt="Screenshot 2025-05-21 at 11 48 37" src="https://github.com/user-attachments/assets/9ce1bfa4-9d6f-4fea-a3e4-70f13397e3be" />

At this point, I guess everyone is ignoring it, so we can turn it on again as soon as these problems are fixed.
