### PR TITLE
RI-7108: Fix E2E pipeline

### DIFF
--- a/tests/e2e/src/vscode.runner.ts
+++ b/tests/e2e/src/vscode.runner.ts
@@ -41,7 +41,7 @@ import { VScodeScripts } from './helpers/scripts/vscodeScripts'
     await exTester.downloadCode()
     await exTester.downloadChromeDriver()
 
-    console.log('📁 Contents of test resources folder:')
+    console.log(`${DEFAULT_STORAGE_FOLDER} contents:`)
     const testResources = fs.readdirSync(DEFAULT_STORAGE_FOLDER)
     testResources.forEach(item => {
       const fullPath = path.join(DEFAULT_STORAGE_FOLDER, item)

--- a/tests/e2e/src/vscode.runner.ts
+++ b/tests/e2e/src/vscode.runner.ts
@@ -40,6 +40,33 @@ import { VScodeScripts } from './helpers/scripts/vscodeScripts'
     // Install VSCode and Chromedriver
     await exTester.downloadCode()
     await exTester.downloadChromeDriver()
+
+    console.log('📁 Contents of test resources folder:')
+    const testResources = fs.readdirSync(DEFAULT_STORAGE_FOLDER)
+    testResources.forEach(item => {
+      const fullPath = path.join(DEFAULT_STORAGE_FOLDER, item)
+      const stats = fs.statSync(fullPath)
+      const type = stats.isDirectory() ? '📂' : '📄'
+      console.log(`${type} ${item}`)
+    })
+
+    // Fix ChromeDriver path for selenium
+    const chromedriverSource = path.join(
+      DEFAULT_STORAGE_FOLDER,
+      'chromedriver-linux64',
+      'chromedriver',
+    )
+    const chromedriverTarget = path.join(DEFAULT_STORAGE_FOLDER, 'chromedriver')
+
+    if (fs.existsSync(chromedriverSource)) {
+      fs.copyFileSync(chromedriverSource, chromedriverTarget)
+      fs.chmodSync(chromedriverTarget, 0o755)
+      console.log(`ChromeDriver moved to expected path: ${chromedriverTarget}`)
+    } else {
+      console.error(`ChromeDriver binary not found at: ${chromedriverSource}`)
+      process.exit(1)
+    }
+
     // Install vsix if not installed yet
     if (!fs.existsSync(extensionDir)) {
       await exTester.installVsix({
@@ -58,9 +85,11 @@ import { VScodeScripts } from './helpers/scripts/vscodeScripts'
 
     let testFilesEnv: string | string[] = process.env.TEST_FILES!
     if (process.env.TEST_FILES) {
-      testFilesEnv = process.env.TEST_FILES.split('\n').map(file => file.trim()).map((file) => {
-        return path.join(__dirname, '..', file)
-      })
+      testFilesEnv = process.env.TEST_FILES.split('\n')
+        .map(file => file.trim())
+        .map(file => {
+          return path.join(__dirname, '..', file)
+        })
 
       // Always prepend setup.js
       const setupTestPath = path.join(
@@ -78,16 +107,16 @@ import { VScodeScripts } from './helpers/scripts/vscodeScripts'
     }
 
     // Run tests
-    await exTester.runTests(
-      testFilesEnv ||
-        path.join(__dirname, '..', 'dist', 'tests', '**', '*.e2e.js'),
-      {
-        settings: 'settings.json',
-        logLevel: logging.Level.INFO,
-        offline: false,
-        resources: [],
-      },
-    )
+    // await exTester.runTests(
+    //   testFilesEnv ||
+    //     path.join(__dirname, '..', 'dist', 'tests', '**', '*.e2e.js'),
+    //   {
+    //     settings: 'settings.json',
+    //     logLevel: logging.Level.INFO,
+    //     offline: false,
+    //     resources: [],
+    //   },
+    // )
     // Terminate extension node process
     VScodeScripts.terminateSpecificNodeProcesses(extensionProcessPath)
   } catch (error) {

--- a/tests/e2e/src/vscode.runner.ts
+++ b/tests/e2e/src/vscode.runner.ts
@@ -46,7 +46,7 @@ import { VScodeScripts } from './helpers/scripts/vscodeScripts'
     testResources.forEach(item => {
       const fullPath = path.join(DEFAULT_STORAGE_FOLDER, item)
       const stats = fs.statSync(fullPath)
-      const type = stats.isDirectory() ? '📂' : '📄'
+      const type = stats.isDirectory() ? '(directory)' : '(file)'
       console.log(`${type} ${item}`)
     })
 

--- a/tests/e2e/src/vscode.runner.ts
+++ b/tests/e2e/src/vscode.runner.ts
@@ -107,16 +107,16 @@ import { VScodeScripts } from './helpers/scripts/vscodeScripts'
     }
 
     // Run tests
-    // await exTester.runTests(
-    //   testFilesEnv ||
-    //     path.join(__dirname, '..', 'dist', 'tests', '**', '*.e2e.js'),
-    //   {
-    //     settings: 'settings.json',
-    //     logLevel: logging.Level.INFO,
-    //     offline: false,
-    //     resources: [],
-    //   },
-    // )
+    await exTester.runTests(
+      testFilesEnv ||
+        path.join(__dirname, '..', 'dist', 'tests', '**', '*.e2e.js'),
+      {
+        settings: 'settings.json',
+        logLevel: logging.Level.INFO,
+        offline: false,
+        resources: [],
+      },
+    )
     // Terminate extension node process
     VScodeScripts.terminateSpecificNodeProcesses(extensionProcessPath)
   } catch (error) {


### PR DESCRIPTION
I don't know what exactly happened:
- the Chrome driver structure changed (because it is zip-ed)
  - `Downloading ChromeDriver 132.0.6834.159 from: https://storage.googleapis.com/chrome-for-testing-public/132.0.6834.159/linux64/chromedriver-linux64.zip`
- vscode-extension-tester changed where it looks for the driver
- something else

And that's why I'm leaving the debug messages - if we end up inthe  same scenario, we'll have the information about the file structure inside the `DEFAULT_STORAGE_FOLDER`