### PR TITLE
 RI-6952: Rename "Length" to "Top-level values"

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -82,7 +82,7 @@
   "will be removed from Redis for VS Code.": "will be removed from Redis for VS Code.",
   "Key Size": "Key Size",
   "Key Size: ": "Key Size: ",
-  "Length": "Length",
+  "Top-level values": "Top-level values",
   "Enter Value": "Enter Value",
   "Add Members": "Add Members",
   "Member": "Member",

--- a/src/webviews/src/modules/key-details-header/components/key-details-header-size-length/KeyDetailsHeaderSizeLength.tsx
+++ b/src/webviews/src/modules/key-details-header/components/key-details-header-size-length/KeyDetailsHeaderSizeLength.tsx
@@ -45,9 +45,9 @@ const KeyDetailsHeaderSizeLength = ({
       {type && (
         <div
           className={styles.subtitleText}
-          data-testid="key-length-text"
+          data-testid="top-level-values"
         >
-          {LENGTH_NAMING_BY_TYPE[type] ?? l10n.t('Length')}
+          {LENGTH_NAMING_BY_TYPE[type] ?? l10n.t('Top-level values')}
           {': '}
           {length ?? '-'}
         </div>

--- a/tests/e2e/src/page-objects/components/editor-view/KeyDetailsView.ts
+++ b/tests/e2e/src/page-objects/components/editor-view/KeyDetailsView.ts
@@ -15,7 +15,7 @@ import { Key } from 'vscode-extension-tester'
 export class KeyDetailsView extends WebView {
   keyType = By.xpath(`//div[contains(@class, '_keyFlexGroup')]`)
   keySize = By.xpath(`//div[@data-testid='key-size-text']`)
-  keyLength = By.xpath(`//div[@data-testid='key-length-text']`)
+  keyLength = By.xpath(`//div[@data-testid='top-level-values']`)
   refreshKeyButton = By.xpath(`//*[@data-testid='key-refresh-btn']`)
   refreshKeyArrow = By.xpath(`//*[@data-testid='key-auto-refresh-config-btn']`)
   refreshKeyMessage = By.xpath(`//*[@data-testid='key-refresh-message']`)


### PR DESCRIPTION
Before:
<img width="400" alt="Screenshot 2025-06-26 at 16 54 07" src="https://github.com/user-attachments/assets/5e8a5f83-3d43-4bc9-90b7-4b7ded873716" />

After:
<img width="484" alt="Screenshot 2025-06-26 at 16 56 42" src="https://github.com/user-attachments/assets/1865f891-b96f-477d-8aa5-6fdbb1e30564" />

