### PR TITLE
Use team handle in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* krum.tyukenov@redis.com pavel.angelov@redis.com dijana.antovska@redis.com artem.horuzhenko@redis.com petar.dzhambazov@redis.com valentin.kirilov@redis.com dimo.georgiev@redis.com
+* @redis/redis-insight-codeowners


### PR DESCRIPTION
## Summary
- Replace the explicit list of individual email addresses in `.github/CODEOWNERS` with the `@redis/redis-insight-codeowners` team so ownership tracks team membership automatically.

## Test plan
- [ ] Verify the team `@redis/redis-insight-codeowners` exists and has write access so CODEOWNERS validation passes.
- [ ] Open a test PR (or check the PR UI) to confirm the team is auto-requested for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates GitHub review routing metadata; no application or runtime behavior changes.
> 
> **Overview**
> **CODEOWNERS** now assigns default review ownership to the **`@redis/redis-insight-codeowners`** GitHub team instead of a fixed list of individual email addresses. Review requests should follow team membership without editing this file when people join or leave.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c3532a19e86bfe9e616794d4a2c97029a4372ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->